### PR TITLE
Generalize distributed testing docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Distributed Testing
 
-Install Ray on at least two nodes. 
+Install Ray on at least one nodes. 
 
 https://docs.ray.io/en/latest/ray-overview/installation.html
 
@@ -14,13 +14,13 @@ pip3 install -U "ray[default]"
 ## Start Ray Head Node
 
 ```shell
-ray start --head --node-ip-address=10.0.0.23 --port=6379 --dashboard-host=0.0.0.0
+ ray start --head --dashboard-host 0.0.0.0 --include-dashboard true
 ```
 
-## Start Ray Worker Nodes(s)
+## Start Ray Worker Nodes(s) (Optional, and MacOS doesn't support multi-node cluster)
 
 ```shell
-ray start --address=10.0.0.23:6379 --redis-password='5241590000000000'
+ray start --address=127.0.0.1:6379
 ```
 
 ## Install DataFusion Ray (on each node)
@@ -44,7 +44,16 @@ maturin develop --release
 
 ## Submit Job
 
+1. If starting the cluster manually, simply connect to the existing cluster instead of reinitializing it.
+```
+# Start a local cluster
+# ray.init(resources={"worker": 1})
+
+# Connect to a cluster
+ray.init()
+```
+
+2. Submit the job to Ray Cluster
 ```shell
-cd examples
-RAY_ADDRESS='http://10.0.0.23:8265'  ray job submit --working-dir `pwd` -- python3 tips.py
+RAY_ADDRESS='http://10.0.0.23:8265'  ray job submit --working-dir examples -- python3 tips.py
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,8 +1,12 @@
-# Distributed Testing
+# Testing
 
-Install Ray on at least one nodes. 
+* [Single Node Testing](#Single-Node-Testing)
+* [Distributed Testing](#Distributed-Testing)
+* [Ray Installation Docs](https://docs.ray.io/en/latest/ray-overview/installation.html)
 
-https://docs.ray.io/en/latest/ray-overview/installation.html
+## Single Node Testing
+
+Install Ray on one (head) node. 
 
 ```shell
 sudo apt install -y python3-pip python3.12-venv
@@ -11,19 +15,23 @@ source venv/bin/activate
 pip3 install -U "ray[default]"
 ```
 
-## Start Ray Head Node
+### Start Ray Head Node
 
 ```shell
  ray start --head --dashboard-host 0.0.0.0 --include-dashboard true
 ```
 
-## Start Ray Worker Nodes(s) (Optional, and MacOS doesn't support multi-node cluster)
+### Start Ray Worker Nodes(s) (Optional)
+
+This is optional, if you go add Ray worker noeds, it becomes distributed.
+
+Also [Ray doesn't support MacOS multi-node cluster](https://docs.ray.io/en/latest/cluster/getting-started.html#where-can-i-deploy-ray-clusters)
 
 ```shell
 ray start --address=127.0.0.1:6379
 ```
 
-## Install DataFusion Ray (on each node)
+### Install DataFusion Ray (on head node)
 
 Clone the repo with the version that you want to test. Run `maturin build --release` in the virtual env.
 
@@ -42,10 +50,10 @@ cd datafusion-ray
 maturin develop --release
 ```
 
-## Submit Job
+### Submit Job
 
-1. If starting the cluster manually, simply connect to the existing cluster instead of reinitializing it.
-```
+1. If started the cluster manually, simply connect to the existing cluster instead of reinitializing it.
+```python
 # Start a local cluster
 # ray.init(resources={"worker": 1})
 
@@ -55,5 +63,67 @@ ray.init()
 
 2. Submit the job to Ray Cluster
 ```shell
-RAY_ADDRESS='http://10.0.0.23:8265'  ray job submit --working-dir examples -- python3 tips.py
+RAY_ADDRESS='http://127.0.0.1:8265' ray job submit --working-dir examples -- python3 tips.py
+```
+
+## Distributed Testing
+
+Install Ray on at least two nodes. 
+
+```shell
+sudo apt install -y python3-pip python3.12-venv
+python3 -m venv venv
+source venv/bin/activate
+pip3 install -U "ray[default]"
+```
+
+### Start Ray Head Node
+
+```shell
+ray start --head --dashboard-host 0.0.0.0 --include-dashboard true
+```
+
+### Start Ray Worker Nodes(s)
+
+Replace `NODE_IP_ADDRESS` with the address accessible in your distributed setup, which will be displayed after the previous step.
+
+```shell
+ray start --address={NODE_IP_ADDRESS}:6379
+```
+
+### Install DataFusion Ray (on each node)
+
+Clone the repo with the version that you want to test. Run `maturin build --release` in the virtual env.
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"
+```
+
+```shell
+pip3 install maturin
+```
+
+```shell
+git clone https://github.com/apache/datafusion-ray.git
+cd datafusion-ray
+maturin develop --release
+```
+
+### Submit Job
+
+1. If starting the cluster manually, simply connect to the existing cluster instead of reinitializing it.
+
+```python
+# Start a local cluster
+# ray.init(resources={"worker": 1})
+
+# Connect to a cluster
+ray.init()
+```
+
+2. Submit the job to Ray Cluster
+
+```shell
+RAY_ADDRESS='http://{NODE_IP_ADDRESS}:8265' ray job submit --working-dir examples -- python3 tips.py
 ```


### PR DESCRIPTION
## The Rationales

1. Remove `redis` args: It used to be that the Ray head used redis to store state and Ray workers connected to the head by referencing the address of the head's Redis server (default port 6379). Ray stopped using redis in 1.11.0 -- to make that transition less disruptive, they made it so that workers still connect to the head by referencing port :6379. [source](https://github.com/ray-project/ray/issues/24920#issuecomment-1132123262)

3. Ensure can run single node cluster on MacOS: Users might want a quick start on their own Mac dev box locally, and be aware that multi-node Ray clusters are only supported on Linux.  So, I make it optional. [source](https://docs.ray.io/en/latest/cluster/getting-started.html#where-can-i-deploy-ray-clusters)

3. Hint user to simply connect to the cluster: if user already created the clusters in command line, they can just connect to it via `ray.init()` without specifying required resources.

<img width="1280" alt="Screenshot 2024-10-07 at 12 06 13 AM" src="https://github.com/user-attachments/assets/7c9e79e8-0564-4364-b639-1bacbfb01045">
