### PR TITLE
Removing non GHCR Docker image tag

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -32,7 +32,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            apache/datafusion-ray
             ghcr.io/apache/datafusion-ray
           tags: |
             type=ref,event=branch


### PR DESCRIPTION
Looking at this failure https://github.com/apache/datafusion-ray/actions/runs/11319285985/job/31475102676 it seems the pipeline is still trying to publish on DockerHub.

Looking better in the documentation here https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
and here https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

it seems the problem is that if there is a tag that doesn't start with ghcr, this is published towards docker registry by default