### PR TITLE
Adding Datafusion Ray tests on an Kind cluster using the Helm chart

### DIFF
--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -68,7 +68,7 @@ jobs:
           load: true
 
       - name: Kind Cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.9.0
         with:
           config: ./k8s/kind-config.yaml
 

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -20,6 +20,11 @@ on:
   push:
   pull_request:
 
+env:
+  RAY_HELM_VERSION: 1.1.0
+  PYTHON_VERSION: 3.9
+  IMAGE_REPOSITORY: ghcr.io/apache/datafusion-ray
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -32,7 +37,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/apache/datafusion-ray
+            ${{ env.IMAGE_REPOSITORY }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -40,6 +45,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,3 +65,59 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          load: true
+
+      - name: Kind Cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          config: ./k8s/kind-config.yaml
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # when set to "true" but frees about 6 GB
+          tool-cache: true
+          docker-images: false
+
+      - name: Extract short SHA
+        run: |
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "IMAGE_TAG=sha-${SHORT_SHA}" >> "$GITHUB_ENV"
+          echo "Extracted short SHA tag: sha-${SHORT_SHA}"
+
+      - name: Load Docker image into Kind cluster
+        run: |
+          kind load docker-image ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} -n chart-testing
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: "3.16.0"
+
+      - name: Deploy helm chart
+        run: |
+          helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+          helm install kuberay-operator kuberay/kuberay-operator --version ${{ env.RAY_HELM_VERSION }}
+          helm install raycluster kuberay/ray-cluster --version ${{ env.RAY_HELM_VERSION }} \
+            --set image.repository=${{ env.IMAGE_REPOSITORY }} \
+            --set image.tag=${{ env.IMAGE_TAG }} \
+            --set imagePullPolicy=Always
+          echo "Deployed Ray cluster with image repository: ${{ env.IMAGE_REPOSITORY }} and tag: ${{ env.IMAGE_TAG }}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-in.txt
+
+      - name: Submit an example ray Job
+        run: |
+          kubectl port-forward service/raycluster-kuberay-head-svc 8265:8265 &
+          export RAY_ADDRESS="http://127.0.0.1:8265"
+          pip  install "ray[default]"
+          ray job submit --working-dir ./examples/ -- python3 tips.py

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -73,7 +73,7 @@ jobs:
           config: ./k8s/kind-config.yaml
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.1.0
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -68,7 +68,7 @@ jobs:
           load: true
 
       - name: Kind Cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.10.0
         with:
           config: ./k8s/kind-config.yaml
 

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -68,12 +68,12 @@ jobs:
           load: true
 
       - name: Kind Cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@0025e74
         with:
           config: ./k8s/kind-config.yaml
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@ab7a4be
         with:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -68,12 +68,12 @@ jobs:
           load: true
 
       - name: Kind Cluster
-        uses: helm/kind-action@0025e74
+        uses: helm/kind-action@v1.10.0
         with:
           config: ./k8s/kind-config.yaml
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@ab7a4be
+        uses: jlumbroso/free-disk-space@v1.1.0
         with:
           # this might remove tools that are actually needed,
           # when set to "true" but frees about 6 GB

--- a/k8s/kind-config.yaml
+++ b/k8s/kind-config.yaml
@@ -1,0 +1,19 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /tmp/kind-node-disk
+        containerPath: /var/lib/containerd
+  - role: worker
+    extraMounts:
+      - hostPath: /tmp/kind-node-disk1
+        containerPath: /var/lib/containerd
+  - role: worker
+    extraMounts:
+      - hostPath: /tmp/kind-node-disk2
+        containerPath: /var/lib/containerd
+  - role: worker
+    extraMounts:
+      - hostPath: /tmp/kind-node-disk3
+        containerPath: /var/lib/containerd


### PR DESCRIPTION
This PR enhances the CI/CD pipeline for Docker and Kubernetes by performing the following steps:
- creating a Kind cluster
- loading on the cluster the image of datafusion-ray
- install the Ray operator via Helm
- install a cluster that uses the image just built
- submit a simple job

See a successful run here https://github.com/edmondop/datafusion-ray/actions/runs/11364615043/job/31611008633#step:15:217

**Blocked by https://issues.apache.org/jira/browse/INFRA-26209**