### PR TITLE
Fix `partitions` as `list[list[pyarrow.RecordBatch]]`

### DIFF
--- a/examples/tips.py
+++ b/examples/tips.py
@@ -52,4 +52,4 @@ df = (
 )
 
 ray_results = ray_ctx.plan(df.execution_plan())
-df_ctx.create_dataframe([ray_results]).show()
+df_ctx.create_dataframe([[ray_results]]).show()


### PR DESCRIPTION
## The issue
Closes https://github.com/apache/datafusion-ray/issues/37

## The rationales
Fix  `create_dataframe(partitions)` as `list[list[pyarrow.RecordBatch]]` of `examples/tips.py`