### PR TITLE
Add working CI tests to validate TPCH across a matrix of python / ray versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,32 +21,43 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
-#concurrency:
-#  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-#cancel-in-progress: true
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  MATURIN_PEP517_ARGS: --profile=dev
 
 jobs:
   test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.image }}
     strategy:
       fail-fast: false
       matrix:
+        platform:
+          - image: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - image: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
         python-version:
-          #- "3.10"
-          #- "3.11"
+          - "3.10"
+          - "3.11"
           - "3.12"
-        toolchain:
-          - "stable"
-
+        ray-version:
+          - "2.40"
+          - "2.41"
+          - "2.42.1"
+          - "2.43"
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
+        id: rust-toolchain-arm
         with:
-          components: clippy,rustfmt
+          target: ${{ matrix.platform.target }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -60,15 +71,28 @@ jobs:
           path: ~/.cargo
           key: cargo-cache-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
 
-      - name: Install dependencies and build
+      - name: install uv
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
 
-      - name: Create virtual env
+      # reset the version of ray in pyproject.toml
+      # to agree align with our matrix version
+      - name: add ray
         run: |
-          uv venv
+          uv add --no-sync 'ray[default]==${{ matrix.ray-version}}'
+
+      # sync the environment, building everything other than datafusion-ray
+      - name: install dependencies
+        run: uv sync --no-install-package datafusion-ray
+        working-directory: ${{ github.workspace }}
+
+      # build datafusion ray honoring the MATURIN_PEP517_ARGS env
+      # var to ensure that we build this in dev mode so its faster
+      - name: maturin develop
+        run: uv run maturin develop --uv
+        working-directory: ${{ github.workspace }}
 
       - name: Cache the generated dataset
         id: cache-tpch-dataset
@@ -80,21 +104,16 @@ jobs:
       - name: create the dataset
         if: ${{ steps.cache-tpch-dataset.outputs.cache-hit != 'true' }}
         run: |
-          uv add duckdb
-          uv run python tpch/make_data.py 1 testdata/tpch/
+          uv run --no-project python tpch/make_data.py 1 testdata/tpch/
 
-      - name: build and install datafusion-ray
-        env:
-          RUST_BACKTRACE: 1
-        run: |
-          uv add 'ray[default]'
-          uv run --no-project maturin develop --uv
-
+      # run the tpcbench.py file with --validate which will cause
+      # it to exit with an error code if any of the queries do not validate
       - name: validate tpch
         env:
           DATAFUSION_RAY_LOG_LEVEL: debug
           RAY_COLOR_PREFIX: 1
           RAY_DEDUP_LOGS: 0
+          RUST_BACKTRACE: 1
         run: |
           uv run python tpch/tpcbench.py \
             --data='file:///${{ github.workspace }}/testdata/tpch/' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,18 +37,16 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - image: ubuntu-24.04
+          - image: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - image: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
         python-version:
-          #- "3.10"
+          - "3.10"
           - "3.11"
-          #- "3.12"
+          - "3.12"
         ray-version:
-          #- "2.40"
-          #- "2.41"
-          #- "2.42.1"
+          - "2.40"
+          - "2.41"
+          - "2.42.1"
           - "2.43"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,15 +83,21 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
+      - name: initial project sync
+        run: |
+          uv sync --no-install-package datafusion-ray --no-install-package ray
+
       # reset the version of ray in pyproject.toml
       # to agree align with our matrix version
       - name: add ray
         run: |
+          cargo --version
           uv add --no-sync 'ray[default]==${{ matrix.ray-version}}'
 
       # sync the environment, building everything other than datafusion-ray
       - name: install dependencies
-        run: uv sync --no-install-package datafusion-ray
+        run: |
+          uv sync --no-install-package datafusion-ray
         working-directory: ${{ github.workspace }}
 
       # build datafusion ray honoring the MATURIN_PEP517_ARGS env
@@ -110,7 +116,7 @@ jobs:
       - name: create the dataset
         if: ${{ steps.cache-tpch-dataset.outputs.cache-hit != 'true' }}
         run: |
-          uv run --no-project python tpch/make_data.py 1 testdata/tpch/
+          uv run tpch/make_data.py 1 testdata/tpch/
 
       # run the tpcbench.py file with --validate which will cause
       # it to exit with an error code if any of the queries do not validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
           uv run python tpch/tpcbench.py \
             --data='file:///${{ github.workspace }}/testdata/tpch/' \
             --concurrency 3 \
-            --partitions-per-worker 2 \
+            --partitions-per-processor 2 \
             --batch-size=8192 \
             --worker-pool-min=20 \
             --validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: main
+name: Python Tests
 on:
   push:
     branches: [main]
@@ -37,27 +37,32 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - image: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
+          #- image: ubuntu-24.04
+          #  target: x86_64-unknown-linux-musl
           - image: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
         python-version:
-          - "3.10"
-          - "3.11"
+          #- "3.10"
+          #- "3.11"
           - "3.12"
         ray-version:
-          - "2.40"
-          - "2.41"
-          - "2.42.1"
+          #- "2.40"
+          #- "2.41"
+          #- "2.42.1"
           - "2.43"
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain-arm
+        id: rust-toolchain
         with:
           target: ${{ matrix.platform.target }}
+
+      - name: Check Rust output
+        id: rust-toolchain-out
+        run: |
+          rustc --version --verbose
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,17 +34,17 @@ jobs:
   validate-tpch:
     runs-on: ${{ matrix.platform.image }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         platform:
-          #- image: ubuntu-24.04
-          #  target: x86_64-unknown-linux-musl
+          - image: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
           - image: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
         python-version:
           #- "3.10"
-          #- "3.11"
-          - "3.12"
+          - "3.11"
+          #- "3.12"
         ray-version:
           #- "2.40"
           #- "2.41"
@@ -85,6 +85,7 @@ jobs:
 
       - name: initial project sync
         run: |
+          cargo --version
           uv sync --no-install-package datafusion-ray --no-install-package ray
 
       # reset the version of ray in pyproject.toml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
         id: rust-toolchain-out
         run: |
           rustc --version --verbose
+          cargo --version
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ env:
   MATURIN_PEP517_ARGS: --profile=dev
 
 jobs:
-  test-matrix:
+  validate-tpch:
     runs-on: ${{ matrix.platform.image }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         platform:
           - image: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   under the License.
 -->
 
+[![Python Tests](https://github.com/robtandy/datafusion-ray/actions/workflows/main.yml/badge.svg)](https://github.com/robtandy/datafusion-ray/actions/workflows/main.yml)
+
 # DataFusion on Ray
 
 ## Overview
@@ -36,16 +38,16 @@ as soon as its inputs are available, leading to a more pipelined execution model
 
 ### Batch Execution
 
-_Note: Batch Execution is not implemented yet. Tracking issue: https://github.com/apache/datafusion-ray/issues/69_
+_Note: Batch Execution is not implemented yet. Tracking issue: <https://github.com/apache/datafusion-ray/issues/69>_
 
-In this mode, execution follows a staged model similar to Apache Spark. Each query stage runs to completion, producing 
+In this mode, execution follows a staged model similar to Apache Spark. Each query stage runs to completion, producing
 intermediate shuffle files that are persisted and used as input for the next stage.
 
 ## Getting Started
 
 See the [contributor guide] for instructions on building DataFusion Ray.
 
-Once installed, you can run queries using DataFusion's familiar API while leveraging the distributed execution 
+Once installed, you can run queries using DataFusion's familiar API while leveraging the distributed execution
 capabilities of Ray.
 
 ```python
@@ -66,6 +68,5 @@ Contributions are welcome! Please open an issue or submit a pull request if you 
 ## License
 
 DataFusion Ray is licensed under Apache 2.0.
-
 
 [contributor guide]: docs/contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,27 @@
 # under the License.
 
 [build-system]
-requires = ["maturin>=0.14"]
+requires = ["maturin>=1.8.1,<2.0"]
 build-backend = "maturin"
 
 [project]
 name = "datafusion-ray"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 classifiers = [
   "Programming Language :: Rust",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
+keywords = [
+  "datafusion",
+  "ray",
+  "dataframe",
+  "rust",
+  "query-engine",
+  "distributed",
+]
 dependencies = [
-  "datafusion>=45.0.0",
+  "ray[default]==2.43.0",
   "pyarrow>=18.0.0",
   "typing-extensions;python_version<'3.13'",
 ]
@@ -36,3 +44,6 @@ dynamic = ["version"]
 
 [tool.maturin]
 module-name = "datafusion_ray._datafusion_ray_internal"
+
+[dependency-groups]
+dev = ["maturin>=1.8.1", "duckdb", "datafusion>=43.0.0"]


### PR DESCRIPTION
### Working CI tpch validation tests

Should fix #11, and maybe eliminates the need for #33.

Now, when the `main` branch is pushed to, or a PR is opened against main, CI will run that will validate TPCH results at scale factor 1.

This test will let us ensure that we do not stray from correct query execution as we iterate.    This test also executes over a matrix of python versions, `3.10, 3.11, 3.12` and ray versions `2.40, 2.41, 2.42.1, 2.43`, to ensure that combinations of these pass.

A status indicator of whether the main branch passes tests is shown in the Readme.

Example execution of these tests can be seen in the fork: https://github.com/robtandy/datafusion-ray/actions/runs/13638548828

### `uv` in addition to `pip`
- Using `uv` for CI makes sense as its so much faster.   Turns out its good for local dev too.  I updated `docs/contributing.md` to document the workflow borrowing much from the `datafusion-python` readme and its workflow.

### Other Small changes
- rename `--partitions-per-worker` to `--partitions-per-processor` in `tpcbench.py`
- return an error return code if one or more queries do not validate in `tpcbench.py`

