### PR TITLE
Add object store support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ object_store = { version = "0.11.0", features = [
 ] }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 prost = "0.13"
+protobuf-src = "2.1"
 pyo3 = { version = "0.23", features = [
   "extension-module",
   "abi3",
@@ -85,7 +86,6 @@ tonic-build = { version = "0.8", default-features = false, features = [
   "prost",
 ] }
 url = "2"
-protobuf-src = "2.1"
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/README.md
+++ b/README.md
@@ -51,12 +51,20 @@ Once installed, you can run queries using DataFusion's familiar API while levera
 capabilities of Ray.
 
 ```python
+# from example in ./examples/http_csv.py
 import ray
 from datafusion_ray import DFRayContext, df_ray_runtime_env
 
 ray.init(runtime_env=df_ray_runtime_env)
-session = DFRayContext()
-df = session.sql("SELECT * FROM my_table WHERE value > 100")
+
+ctx = DFRayContext()
+ctx.register_csv(
+    "aggregate_test_100",
+    "https://github.com/apache/arrow-testing/raw/master/data/csv/aggregate_test_100.csv",
+)
+
+df = ctx.sql("SELECT c1,c2,c3 FROM aggregate_test_100 LIMIT 5")
+
 df.show()
 ```
 

--- a/examples/http_csv.py
+++ b/examples/http_csv.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# this is a port of the example at
+# https://github.com/apache/datafusion/blob/45.0.0/datafusion-examples/examples/query-http-csv.rs
+
+import ray
+
+from datafusion_ray import DFRayContext, df_ray_runtime_env
+
+
+def main():
+    ctx = DFRayContext()
+    ctx.register_csv(
+        "aggregate_test_100",
+        "https://github.com/apache/arrow-testing/raw/master/data/csv/aggregate_test_100.csv",
+    )
+
+    df = ctx.sql("SELECT c1,c2,c3 FROM aggregate_test_100 LIMIT 5")
+
+    df.show()
+
+
+if __name__ == __name__:
+    ray.init(namespace="http_csv", runtime_env=df_ray_runtime_env)
+    main()

--- a/examples/tips.py
+++ b/examples/tips.py
@@ -16,40 +16,27 @@
 # under the License.
 
 import argparse
-import datafusion
+import os
 import ray
 
-from datafusion_ray import DFRayContext
+from datafusion_ray import DFRayContext, df_ray_runtime_env
 
 
 def go(data_dir: str):
     ctx = DFRayContext()
-    # we could set this value to however many CPUs we plan to give each
-    # ray task
-    ctx.set("datafusion.execution.target_partitions", "1")
-    ctx.set("datafusion.optimizer.enable_round_robin_repartition", "false")
 
-    ctx.register_parquet("tips", f"{data_dir}/tips*.parquet")
+    ctx.register_parquet("tips", os.path.join(data_dir, "tips.parquet"))
 
     df = ctx.sql(
         "select sex, smoker, avg(tip/total_bill) as tip_pct from tips group by sex, smoker order by sex, smoker"
     )
     df.show()
 
-    print("no ray result:")
-
-    # compare to non ray version
-    ctx = datafusion.SessionContext()
-    ctx.register_parquet("tips", f"{data_dir}/tips*.parquet")
-    ctx.sql(
-        "select sex, smoker, avg(tip/total_bill) as tip_pct from tips group by sex, smoker order by sex, smoker"
-    ).show()
-
 
 if __name__ == "__main__":
-    ray.init(namespace="tips")
+    ray.init(namespace="tips", runtime_env=df_ray_runtime_env)
     parser = argparse.ArgumentParser()
-    parser.add_argument("--data-dir", required=True, help="path to tips*.parquet files")
+    parser.add_argument("--data-dir", required=True, help="path to tips.parquet files")
     args = parser.parse_args()
 
     go(args.data_dir)

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,7 +27,6 @@ use std::sync::Arc;
 use crate::dataframe::DFRayDataFrame;
 use crate::physical::RayStageOptimizerRule;
 use crate::util::{maybe_register_object_store, ResultExt};
-use url::Url;
 
 /// Internal Session Context object for the python class DFRayContext
 #[pyclass]

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,7 @@ use arrow::util::pretty;
 use arrow_flight::{FlightClient, FlightData, Ticket};
 use async_stream::stream;
 use datafusion::common::internal_datafusion_err;
-use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
 use datafusion::datasource::listing::{ListingOptions, ListingTableUrl};
 use datafusion::datasource::physical_plan::{

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,11 +20,14 @@ use arrow::util::pretty;
 use arrow_flight::{FlightClient, FlightData, Ticket};
 use async_stream::stream;
 use datafusion::common::internal_datafusion_err;
-use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion::datasource::file_format::parquet::ParquetFormat;
-use datafusion::datasource::listing::ListingOptions;
-use datafusion::datasource::physical_plan::ParquetExec;
+use datafusion::datasource::listing::{ListingOptions, ListingTableUrl};
+use datafusion::datasource::physical_plan::{
+    ArrowExec, AvroExec, CsvExec, NdJsonExec, ParquetExec,
+};
 use datafusion::error::DataFusionError;
+use datafusion::execution::object_store::ObjectStoreUrl;
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, SessionStateBuilder};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{displayable, ExecutionPlan, ExecutionPlanProperties};
@@ -32,10 +35,16 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_proto::physical_plan::AsExecutionPlan;
 use datafusion_python::utils::wait_for_future;
 use futures::{Stream, StreamExt};
+use log::debug;
+use object_store::aws::AmazonS3Builder;
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::http::HttpBuilder;
+use object_store::ObjectStore;
 use parking_lot::Mutex;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList};
 use tonic::transport::Channel;
+use url::Url;
 
 use crate::codec::RayCodec;
 use crate::processor_service::ServiceClients;
@@ -410,6 +419,12 @@ async fn exec_sql(
     for (name, path) in tables {
         let opt =
             ListingOptions::new(Arc::new(ParquetFormat::new())).with_file_extension(".parquet");
+        debug!("exec_sql: registering table {} at {}", name, path);
+
+        let url = ListingTableUrl::parse(&path)?;
+
+        maybe_register_object_store(&ctx, url.as_ref())?;
+
         ctx.register_listing_table(&name, &path, opt, None, None)
             .await?;
     }
@@ -432,21 +447,122 @@ async fn exec_sql(
 ///   the `url` identifies the parquet files for each listing table and see
 ///   [`datafusion::datasource::listing::ListingTableUrl::parse`] for details
 ///   of supported URL formats
+///  * `listing`: boolean indicating whether this is a listing table path or not
 #[pyfunction]
+#[pyo3(signature = (query, tables, listing=false))]
 pub fn exec_sql_on_tables(
     py: Python,
     query: String,
     tables: Bound<'_, PyList>,
+    listing: bool,
 ) -> PyResult<PyObject> {
     let table_vec = {
         let mut v = Vec::with_capacity(tables.len());
         for entry in tables.iter() {
-            v.push(entry.extract::<(String, String)>()?);
+            let (name, path) = entry.extract::<(String, String)>()?;
+            let path = if listing { format!("{path}/") } else { path };
+            v.push((name, path));
         }
         v
     };
     let batch = wait_for_future(py, exec_sql(query, table_vec))?;
     batch.to_pyarrow(py)
+}
+
+pub(crate) fn register_object_store_for_paths_in_plan(
+    ctx: &SessionContext,
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<(), DataFusionError> {
+    let check_plan = |plan: Arc<dyn ExecutionPlan>| -> Result<_, DataFusionError> {
+        for input in plan.children().into_iter() {
+            if let Some(node) = input.as_any().downcast_ref::<ParquetExec>() {
+                let url = &node.base_config().object_store_url;
+                maybe_register_object_store(ctx, url.as_ref())?
+            } else if let Some(node) = input.as_any().downcast_ref::<CsvExec>() {
+                let url = &node.base_config().object_store_url;
+                maybe_register_object_store(ctx, url.as_ref())?
+            } else if let Some(node) = input.as_any().downcast_ref::<NdJsonExec>() {
+                let url = &node.base_config().object_store_url;
+                maybe_register_object_store(ctx, url.as_ref())?
+            } else if let Some(node) = input.as_any().downcast_ref::<AvroExec>() {
+                let url = &node.base_config().object_store_url;
+                maybe_register_object_store(ctx, url.as_ref())?
+            } else if let Some(node) = input.as_any().downcast_ref::<ArrowExec>() {
+                let url = &node.base_config().object_store_url;
+                maybe_register_object_store(ctx, url.as_ref())?
+            }
+        }
+        Ok(Transformed::no(plan))
+    };
+
+    plan.transform_down(check_plan)?;
+
+    Ok(())
+}
+
+/// Registers an object store with the given session context based on the provided path.
+///
+/// # Arguments
+///
+/// * `ctx` - A reference to the `SessionContext` where the object store will be registered.
+/// * `path` - A string slice that holds the path or URL of the object store.
+pub(crate) fn maybe_register_object_store(
+    ctx: &SessionContext,
+    url: &Url,
+) -> Result<(), DataFusionError> {
+    let (ob_url, object_store) = if url.as_str().starts_with("s3://") {
+        let bucket = url
+            .host_str()
+            .ok_or(internal_datafusion_err!("missing bucket name in s3:// url"))?;
+
+        let s3 = AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()?;
+        (
+            ObjectStoreUrl::parse(format!("s3://{bucket}"))?,
+            Arc::new(s3) as Arc<dyn ObjectStore>,
+        )
+    } else if url.as_str().starts_with("gs://") || url.as_str().starts_with("gcs://") {
+        let bucket = url
+            .host_str()
+            .ok_or(internal_datafusion_err!("missing bucket name in gs:// url"))?;
+
+        let gs = GoogleCloudStorageBuilder::new()
+            .with_bucket_name(bucket)
+            .build()?;
+
+        (
+            ObjectStoreUrl::parse(format!("gs://{bucket}"))?,
+            Arc::new(gs) as Arc<dyn ObjectStore>,
+        )
+    } else if url.as_str().starts_with("http://") || url.as_str().starts_with("https://") {
+        let scheme = url.scheme();
+
+        let host = url.host_str().ok_or(internal_datafusion_err!(
+            "missing host name in {}:// url",
+            scheme
+        ))?;
+
+        let http = HttpBuilder::new()
+            .with_url(format!("{scheme}://{host}"))
+            .build()?;
+
+        (
+            ObjectStoreUrl::parse(format!("{scheme}://{host}"))?,
+            Arc::new(http) as Arc<dyn ObjectStore>,
+        )
+    } else {
+        let local = object_store::local::LocalFileSystem::new();
+        (
+            ObjectStoreUrl::parse("file://")?,
+            Arc::new(local) as Arc<dyn ObjectStore>,
+        )
+    };
+
+    debug!("Registering object store for {}", ob_url);
+
+    ctx.register_object_store(ob_url.as_ref(), object_store);
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Basic Object store support

### Changes:

- Updated `register_parquet`, `register_listing_table`, and added `register_csv` such that they will automatically register an object store based on the Url of the path provided.   Local paths, relative or absolute, are interpreted as a `file://` url, using the parse functionality in `ListingTableUrl` from `datafusion`.
- Added `example/http_csv.py` a port of `https://github.com/apache/datafusion/blob/45.0.0/datafusion- examples/examples/query-http-csv.rs`
- Updated the example in the `Readme.md` to be a working example using a github hosted csv file.

###  Object store credentials
In this PR, all object stores are automatically registered - which can be really nice - and the trade off is that we rely on the cloud provider SDKs to gather credentials from their environment, or local files, rather than explicitly providing them.

In a future release we can add more configurability here.

Looks like a few formatting changes snuck in here from editing.  I would like to defer sorting out those details until we have commit hooks to ensure proper and consistent file formatting.
