### PR TITLE
Benchmarking fixes:  query 15, update validator, formatting, ray scheduling fix

### DIFF
--- a/datafusion_ray/core.py
+++ b/datafusion_ray/core.py
@@ -249,7 +249,7 @@ class DFRayProcessorPool:
         log.info("all processors shutdown")
 
 
-@ray.remote(num_cpus=0)
+@ray.remote(num_cpus=0.01, scheduling_strategy="SPREAD")
 class DFRayProcessor:
     def __init__(self, processor_key):
         self.processor_key = processor_key
@@ -317,7 +317,7 @@ class InternalStageData:
         return f"""Stage: {self.stage_id}, pg: {self.partition_group}, child_stages:{self.child_stage_ids}, listening addr:{self.remote_addr}"""
 
 
-@ray.remote(num_cpus=0)
+@ray.remote(num_cpus=0.01, scheduling_strategy="SPREAD")
 class DFRayContextSupervisor:
     def __init__(
         self,

--- a/datafusion_ray/util.py
+++ b/datafusion_ray/util.py
@@ -1,4 +1,4 @@
 from datafusion_ray._datafusion_ray_internal import (
-    exec_sql_on_tables,
+    LocalValidator,
     prettify,
 )

--- a/src/dataframe.rs
+++ b/src/dataframe.rs
@@ -50,10 +50,10 @@ use crate::max_rows::MaxRowsExec;
 use crate::pre_fetch::PrefetchExec;
 use crate::stage::DFRayStageExec;
 use crate::stage_reader::DFRayStageReaderExec;
+use crate::util::ResultExt;
 use crate::util::collect_from_stage;
 use crate::util::display_plan_with_partition_counts;
 use crate::util::physical_plan_to_bytes;
-use crate::util::ResultExt;
 
 /// Internal rust class beyind the DFRayDataFrame python object
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ fn _datafusion_ray_internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<dataframe::DFRayDataFrame>()?;
     m.add_class::<dataframe::PyDFRayStage>()?;
     m.add_class::<processor_service::DFRayProcessorService>()?;
+    m.add_class::<util::LocalValidator>()?;
     m.add_function(wrap_pyfunction!(util::prettify, m)?)?;
-    m.add_function(wrap_pyfunction!(util::exec_sql_on_tables, m)?)?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #81 

Small fixes that came up during benchmarking.

- query 15 (and others ) now runs all statements
- `util::exec_sql_on_tables` replaced with `util::LocalValidator` as keeping state in its own `ctx` it can more easily handle multiple queries
- update `ray.remote` annotations to denote the `SPREAD` scheduling strategy
- update `ray.remote` to require `num_cpus=0.01` such that we do ask for a small amount of logical CPU, and this way can avoid being scheduled on the head node
- Clippy formatted
- `black --line-length 79` formatted python

Note that DDL/DML statements, like in query 15, end up producing an empty physical plan and are sent to a `DFRayProcessor` for execution.  This doesn't produce an incorrect result, but we should optimize this in a subsequent improvement.