### PR TITLE
CI: Add CodeQL workflow for GitHub Actions security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Actions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: actions
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,14 +40,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 # v4
       with:
         languages: actions
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4
       with:
         category: "/language:actions"


### PR DESCRIPTION
This adds a CodeQL workflow to scan GitHub Actions workflow files for security issues such as script injection, use of untrusted input, and other misconfigurations.

Reference: https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/

**Triggers:**
- Push and PR to `main`
- Weekly scheduled scan (Mondays at 4:16 UTC)

This is based on [Apache Infra recommendation](https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+Security),

> IMPORTANT! You should enable CodeQL "actions" scanning in your repositories as described in https://github.blog/security/application-security/how-to-secure-your-github-actions-workflows-with-codeql/ - this will scan and flag those issues described below and many more automatically for you

---
*This PR was generated by https://gist.github.com/kevinjqliu/97d24733c7b75cd92b68bf8f5b247891*